### PR TITLE
[FIX] QFileDialog + image load

### DIFF
--- a/source/puddlestuff/puddleobjects.py
+++ b/source/puddlestuff/puddleobjects.py
@@ -1754,7 +1754,7 @@ class PicWidget(QWidget):
 
         if not filename:
             default_fn = os.path.join(
-                os.path.dirname(self.lastfilename), 'folder.jpg').encode('utf8')
+                os.path.dirname(self.lastfilename), 'folder.jpg')
             selectedFile = QFileDialog.getOpenFileName(self,
                 translate("Artwork", 'Select Image...'), default_fn,
                 translate("Artwork", "JPEG & PNG Images (*.jpg *.jpeg *.png);;JPEG Images (*.jpg *.jpeg);;PNG Images (*.png);;All Files(*.*)"))
@@ -1925,7 +1925,7 @@ class PicWidget(QWidget):
             selectedFile = QFileDialog.getSaveFileName(
                 self,
                 translate("Artwork", 'Save artwork as...'),
-                tempfilename.encode('utf8'),
+                tempfilename,
                 translate("Artwork", "JPEG Images (*.jpg);;PNG Images (*.png);;All Files(*.*)"))
             filename = selectedFile[0]
             if not filename:
@@ -1987,7 +1987,7 @@ class PicWidget(QWidget):
                     data = urlopen(filename)
                 except (ValueError, RetrievalError):
                     try:
-                        data = open(filename, 'r').read()
+                        data = open(filename, 'rb').read()
                     except EnvironmentError:
                         continue
 

--- a/source/puddlestuff/puddleobjects.py
+++ b/source/puddlestuff/puddleobjects.py
@@ -1974,6 +1974,8 @@ class PicWidget(QWidget):
         from .tagsources import RetrievalError, urlopen
         images = []
         
+        if isinstance(filenames, tuple):
+            filenames = filenames[0]
         for filename in filenames:
             image = QImage()
             if filename.startswith(":/"):

--- a/source/puddlestuff/tagsources/__init__.py
+++ b/source/puddlestuff/tagsources/__init__.py
@@ -197,9 +197,9 @@ def urlopen(url, mask=True, code=False):
             raise RetrievalError(
                 translate("Tag Sources", "Page doesn't exist"))
         if code:
-            return page.read().decode(), page.code
+            return page.read(), page.code
         else:
-            return page.read().decode()
+            return page.read()
     except six.moves.urllib.error.URLError as e:
         try:
             msg = u'%s (%s)' % (e.reason.strerror, e.reason.errno)


### PR DESCRIPTION
Little contribution for making to work the addition/save of images through select file dialog.

- Don't encode strings that are passed to QFileDialog
- Open image file as binary
- Make drag and drop image to work
  - Remove .decode() as it's already read as unicode
  - Solve argument passing incompatibility, as the list is encapsulated in a tuple.