### PR TITLE
Fix for AttributeError in CaselessDict method

### DIFF
--- a/source/puddlestuff/masstag/__init__.py
+++ b/source/puddlestuff/masstag/__init__.py
@@ -20,6 +20,8 @@ import six
 from six.moves import map
 from six.moves import zip
 
+import functools
+
 def set_status(v):
     print(v)
 
@@ -485,11 +487,10 @@ def replace_tracknumbers(files, tracks):
     if len(files) != len(tracks):
         return
 
-    files = sorted(files, cmp=natcasecmp,
-        key=lambda f: to_string(f.get('track', f[FILENAME])))
+    files = sorted(files, key=lambda f: to_string(f.get('track', f[FILENAME])))
     try:
-        tracks = sorted(tracks, cmp=natcasecmp, key=itemgetter('track'))
-        tracks = sorted(tracks, cmp=natcasecmp, key=itemgetter('discnumber'))
+        tracks = sorted(tracks, key=itemgetter('track'))
+        tracks = sorted(tracks, key=itemgetter('discnumber'))
     except KeyError:
         return
 


### PR DESCRIPTION
The error message is as follows:

```
Traceback (most recent call last):
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/dialogs.py", line 585, in lookup
    self._start()
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/dialogs.py", line 620, in _start
    tag_groups = split_files(self._status['selectedfiles'],
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/__init__.py", line 531, in split_files
    tag_groups.append(list(map(copy_audio, album_files)))
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/masstag/__init__.py", line 521, in copy_audio
    audio_copy = deepcopy(f)
  File "/usr/lib64/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/audioinfo/vorbis.py", line 117, in __deepcopy__
    cls.set_fundamentals(deepcopy(self.__tags),
  File "/usr/lib64/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/home/green/dev/projects/python/puddletag/puddletag/source/puddlestuff/audioinfo/util.py", line 623, in __deepcopy__
    for key, value in dict.iteritems(self):
AttributeError: type object 'dict' has no attribute 'iteritems'
launch.bash: line 3:  4516 Aborted                 (core dumped) PYTHONPATH=source/ ./source/puddletag
```

I noticed the problem when I was trying to fix the mass tagging crash https://github.com/sandrotosi/puddletag/issues/4

The error occured when I pressed the search button on the mass tagging dialog when it was empty, with no settings changed.

I don't know if its still a problem, so let me know if you can't reproduce it