### PR TITLE
CDDB - replace freedb.org (no longer avialable) support with gnudb.org

### DIFF
--- a/source/puddlestuff/tagsources/CDDB.py
+++ b/source/puddlestuff/tagsources/CDDB.py
@@ -24,7 +24,7 @@ else:
 
 # Use protocol version 5 to get DYEAR and DGENRE fields.
 proto = 5
-default_server = 'http://freedb.freedb.org/~cddb/cddb.cgi'
+default_server = 'http://gnudb.gnudb.org/~cddb/cddb.cgi'
 
 
 def query(track_info, server_url=default_server,


### PR DESCRIPTION
freedb.org is no longer available. That's why the related tagging feature is no longer working.

gnudb.org is the alternative, basically a copy, using the same API.